### PR TITLE
chore: switch to ARM64 postgis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: postgis
-    image: postgis/postgis:latest
+    image: imresamu/postgis-arm64:16-3.4.3-bullseye
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:


### PR DESCRIPTION
This PR switched the docker image for PostGIS to one that supports Apple Sillicon chipsets