### PR TITLE
feat(backed): add admin endpoints and api key validation for those endpoints

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ psycopg
 psycopg2-binary
 pytest
 testcontainers[all]
+numpy

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,10 +1,12 @@
 from functools import cache
+from uuid import uuid4
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 @cache
 def get_settings():
+    print("settings =", Settings().model_dump_json(indent=2))
     return Settings()
 
 
@@ -15,3 +17,6 @@ class Settings(BaseSettings):
     db_host: str = "localhost"
     db_port: int = 5432
     db_name: str = "postgres"
+    admin_key: str = str(uuid4())
+
+    model_config = SettingsConfigDict(env_file=".env")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -2,16 +2,16 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Annotated, List
 
-from fastapi import Depends, FastAPI
-from sqlmodel import Session, select
-
-from .config import get_settings
-from .postgis import DbReports, create_db_and_tables, get_session
+import numpy as np
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.security import APIKeyHeader
+from sqlmodel import Session, delete, select
+from src.config import Settings, get_settings
+from src.postgis import DbReports, create_db_and_tables, get_session
 
 # isort: off
 # these need to be imported in a certain order
-from .utils import add_root_to_path  # noqa
-
+from .utils import add_root_to_path  # noqa isort:skip
 from shared.models import Point, Report
 
 
@@ -21,6 +21,16 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 SessionDep = Annotated[Session, Depends(get_session)]
+api_key_header = APIKeyHeader(name="X-Admin-Key")
+
+
+def validate_api_key(
+    api_key: Annotated[str, Security(api_key_header)],
+    settings: Annotated[Settings, Depends(get_settings)],
+):
+    if api_key != settings.admin_key:
+        raise HTTPException(status_code=403, detail="Invalid API key")
+    return api_key
 
 
 @asynccontextmanager
@@ -58,3 +68,27 @@ def get_report(id: int, session: SessionDep) -> Report:
 def get_all_reports(session: SessionDep) -> List[Report]:
     reports = session.exec(select(DbReports)).all()
     return [report.as_report() for report in reports]
+
+
+@app.delete("/admin/reports")
+def delete_all_reports(
+    session: SessionDep,
+    api_key: str = Security(validate_api_key),
+) -> dict:
+    deleted_count = session.exec(delete(DbReports)).rowcount
+    session.commit()
+    return {"message": f"Deleted {deleted_count} reports"}
+
+
+@app.post("/admin/reports")
+def create_mock_reports(
+    location: Point,
+    amount: int,
+    session: SessionDep,
+    api_key: str = Security(validate_api_key),
+) -> List[Report]:
+    points = np.random.normal(size=(amount, 2)) * np.array([[0.05, 0.05]]) + np.array([[location.lat, location.lng]])
+    db_reports = [DbReports(geom=Point(lat=point[0], lng=point[1]).as_geom()) for point in points]
+    session.add_all(db_reports)
+    session.commit()
+    return [db_report.as_report() for db_report in db_reports]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,12 +20,13 @@ def postgis():
         yield postgis
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def test_app(postgis):
     def get_test_settings():
         return Settings(
             db_host=postgis.get_container_host_ip(),
             db_port=postgis.get_exposed_port(5432),
+            admin_key="test_key",
         )
 
     app.dependency_overrides[get_settings] = get_test_settings

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_root(client):
     response = client.get("/")
     assert response.status_code == 200
@@ -54,3 +57,62 @@ def test_get_all_reports(client):
     received_ids = [report["id"] for report in data]
     for created_id in created_ids:
         assert created_id in received_ids
+
+
+@pytest.fixture
+def admin_headers():
+    return {"X-Admin-Key": "test_key"}
+
+
+@pytest.fixture
+def invalid_admin_headers():
+    return {"X-Admin-Key": "wrong_key"}
+
+
+def test_delete_all_reports_unauthorized(client):
+    response = client.delete("/admin/reports")
+    assert response.status_code == 403
+
+
+def test_delete_all_reports_wrong_key(client, invalid_admin_headers):
+    response = client.delete("/admin/reports", headers=invalid_admin_headers)
+    assert response.status_code == 403
+
+
+def test_delete_all_reports(client, admin_headers):
+    # First create some reports
+    points = [{"lat": 45.5231, "lng": -122.6765}, {"lat": 40.7128, "lng": -74.0060}]
+    for point in points:
+        client.post("/report", json=point)
+
+    # Delete all reports
+    response = client.delete("/admin/reports", headers=admin_headers)
+    assert response.status_code == 200
+    assert response.json()["message"].startswith("Deleted")
+    assert "2" in response.json()["message"]
+
+    # Verify reports are gone
+    response = client.get("/reports")
+    assert len(response.json()) == 0
+
+
+def test_create_mock_reports_unauthorized(client):
+    payload = {"location": {"lat": 45.5231, "lng": -122.6765}, "amount": 5}
+    response = client.post("/admin/reports", json=payload)
+    assert response.status_code == 403
+
+
+def test_create_mock_reports(client, admin_headers):
+    center_point = {"lat": 45.5231, "lng": -122.6765}
+    response = client.post("/admin/reports", params={"amount": 5}, json=center_point, headers=admin_headers)
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 5
+
+    # Check that points are within reasonable distance
+    center_lat = center_point["lat"]
+    center_lng = center_point["lng"]
+    for report in data:
+        assert abs(report["location"]["lat"] - center_lat) < 0.5
+        assert abs(report["location"]["lng"] - center_lng) < 0.5


### PR DESCRIPTION
**Based on PR** #6 

This pull request introduces several new features and improvements, including enhanced API functionality, database schema updates, and new utility functions. The most significant changes are the addition of new dependencies, API endpoints for managing reports, and comprehensive test coverage.

### Dependencies and Configuration:
* Added new dependencies `shapely` and `numpy` to `backend/requirements.txt` and `geoalchemy2` and `shapely` to `shared/requirements.txt` to support geometric operations and numerical computations. [[1]](diffhunk://#diff-a780f027052bed3bff6ce9850db4a0e66358b86503cf4586e846ce88afa2e9bcR7-R12) [[2]](diffhunk://#diff-48e3a37d64a43edfe23c0a517a019e51a38336af0bb90e6f985b83b41cac6918R3-R4)
* Introduced `admin_key` to `Settings` class in `backend/src/config.py` for API key validation and added `.env` file support. [[1]](diffhunk://#diff-fa387937a3367f0354dbd2e05e512204045eda9936c5a20c15b8ca8d7941296bR2-R9) [[2]](diffhunk://#diff-fa387937a3367f0354dbd2e05e512204045eda9936c5a20c15b8ca8d7941296bR20-R22)

### API Enhancements:
* Implemented new API endpoints in `backend/src/main.py` for creating, retrieving, and deleting reports, including admin-specific endpoints protected by API key validation. [[1]](diffhunk://#diff-1aa7be8fd177060491e662a7eb3bd936b827847c803cd95f08e3ff1c46160dcdL3-R33) [[2]](diffhunk://#diff-1aa7be8fd177060491e662a7eb3bd936b827847c803cd95f08e3ff1c46160dcdR43-R94)

### Database Schema and Utilities:
* Renamed `Reports` class to `DbReports` in `backend/src/postgis.py` and added methods for converting to and from `Report` model. Introduced `timestamp` field.
* Added utility function `add_root_to_path` in `backend/src/utils.py` to modify `sys.path` for easier imports.

### Testing:
* Enhanced test setup in `backend/tests/conftest.py` to clear reports between tests and added fixtures for API key headers. [[1]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cR6-R14) [[2]](diffhunk://#diff-aacea3e16f9fecd307f1a11567ba7a1abb8a6007266aec3b89dd65454130b76cL19-R45)
* Added comprehensive tests for new API endpoints in `backend/tests/test_main.py`.